### PR TITLE
feat(experimental): add RIP-7560 account features

### DIFF
--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -2,6 +2,7 @@ import type { Address, TypedData } from 'abitype'
 
 import type { SmartAccount } from '../account-abstraction/accounts/types.js'
 import type { Authorization } from '../experimental/eip7702/types/authorization.js'
+import type { NativeSmartAccount } from '../experimental/rip7560/accounts/types.js'
 import type { HDKey } from '../types/account.js'
 import type { Hash, Hex, SignableMessage } from '../types/misc.js'
 import type {
@@ -16,7 +17,10 @@ import type { SerializeTransactionFn } from '../utils/transaction/serializeTrans
 import type { SignAuthorizationReturnType } from './utils/signAuthorization.js'
 
 export type Account<address extends Address = Address> = OneOf<
-  JsonRpcAccount<address> | LocalAccount<string, address> | SmartAccount
+  | JsonRpcAccount<address>
+  | LocalAccount<string, address>
+  | SmartAccount
+  | NativeSmartAccount
 >
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -119,7 +119,7 @@ export async function estimateContractGas<
       to: address,
       ...request,
     } as unknown as EstimateGasParameters)
-    return gas
+    return gas as bigint
   } catch (error) {
     const account = request.account ? parseAccount(request.account) : undefined
     throw getContractError(error as BaseError, {

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -163,6 +163,18 @@ export async function sendTransaction<
     maxPriorityFeePerGas,
     nonce,
     value,
+    nonceKey,
+    sender,
+    executionData,
+    deployer,
+    deployerData,
+    paymaster,
+    paymasterData,
+    builderFee,
+    verificationGasLimit,
+    paymasterVerificationGasLimit,
+    paymasterPostOpGasLimit,
+    type,
     ...rest
   } = parameters
 
@@ -194,7 +206,7 @@ export async function sendTransaction<
       return undefined
     })()
 
-    if (account.type === 'json-rpc') {
+    if (account.type === 'json-rpc' || account.type === 'native-smart') {
       let chainId: number | undefined
       if (chain !== null) {
         chainId = await getAction(client, getChainId, 'getChainId')({})
@@ -224,6 +236,17 @@ export async function sendTransaction<
         nonce,
         to,
         value,
+        nonceKey,
+        sender,
+        executionData,
+        deployer,
+        deployerData,
+        paymaster,
+        paymasterData,
+        builderFee,
+        verificationGasLimit,
+        paymasterVerificationGasLimit,
+        paymasterPostOpGasLimit,
       } as TransactionRequest)
       return await client.request(
         {

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -241,6 +241,7 @@ import {
   type SendRawTransactionReturnType,
   sendRawTransaction,
 } from '../../actions/wallet/sendRawTransaction.js'
+import type { EstimateRIP7560TransactionGasReturnType } from '../../experimental/rip7560/types/gas.js'
 import type { Account } from '../../types/account.js'
 import type { BlockNumber, BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
@@ -491,7 +492,7 @@ export type PublicActions<
    */
   estimateGas: (
     args: EstimateGasParameters<chain>,
-  ) => Promise<EstimateGasReturnType>
+  ) => Promise<EstimateGasReturnType | EstimateRIP7560TransactionGasReturnType>
   /**
    * Returns the balance of an address in wei.
    *

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -84,6 +84,19 @@ export {
   type VerifyAuthorizationErrorType,
   verifyAuthorization,
 } from './eip7702/utils/verifyAuthorization.js'
+export {
+  type ToNativeSmartAccountParameters,
+  type ToNativeSmartAccountReturnType,
+  toNativeSmartAccount,
+} from './rip7560/accounts/toNativeSmartAccount.js'
+export {
+  type ToSimpleNativeSmartAccountParameters,
+  type ToSimpleNativeSmartAccountReturnType,
+  type SimpleNativeSmartAccountImplementation,
+  toSimpleNativeSmartAccount,
+} from './rip7560/accounts/implementations/toSimpleNativeSmartAccount.js'
+export type { EstimateRIP7560TransactionGasReturnType } from './rip7560/types/gas.js'
+export type { Calls } from './rip7560/types/calls.js'
 
 export {
   type GrantPermissionsParameters,

--- a/src/experimental/rip7560/accounts/types.ts
+++ b/src/experimental/rip7560/accounts/types.ts
@@ -1,0 +1,242 @@
+import type { Address, TypedData } from 'abitype'
+import type { SignReturnType as WebAuthnSignReturnType } from 'webauthn-p256'
+
+import type { Client } from '../../../clients/createClient.js'
+import type { Hash, Hex, SignableMessage } from '../../../types/misc.js'
+import type { TypedDataDefinition } from '../../../types/typedData.js'
+import type {
+  Assign,
+  ExactPartial,
+  IsNarrowable,
+} from '../../../types/utils.js'
+import type { GetTransactionType } from '../../../utils/index.js'
+import type { NonceManager } from '../../../utils/nonceManager.js'
+import type { SerializeTransactionFn } from '../../../utils/transaction/serializeTransaction.js'
+
+import type {
+  TransactionRequest,
+  TransactionSerializable,
+  TransactionSerialized,
+} from ',,/../../types/transaction.js'
+import type { EstimateRIP7560TransactionGasReturnType } from '../types/gas.js'
+
+type Call = {
+  to: Hex
+  data?: Hex | undefined
+  value?: bigint | undefined
+}
+
+export type NativeSmartAccountImplementation<extend extends object = object> = {
+  /** Client used to retrieve Smart Account data, and perform signing (if owner is a JSON-RPC Account). */
+  client: Client
+  /** Extend the Smart Account with custom properties. */
+  extend?: extend | undefined
+  /**
+   * Retrieves the Smart Account's address.
+   *
+   * @example
+   * ```ts
+   * const address = await account.getAddress()
+   * // '0x...'
+   * ```
+   */
+  getAddress: () => Promise<Address>
+  /**
+   * Decodes calldata into structured calls.
+   *
+   * @example
+   * ```ts
+   * const calls = await account.decodeCalls('0x...')
+   * // [{ to: '0x...', data: '0x...', value: 100n }, ...]
+   * ```
+   */
+  decodeCalls?: ((data: Hex) => Promise<readonly Call[]>) | undefined
+  /**
+   * Encodes the calls into calldata for executing a User Operation.
+   *
+   * @example
+   * ```ts
+   * const callData = await account.encodeCalls([
+   *   { to: '0x...', data: '0x...' },
+   *   { to: '0x...', data: '0x...', value: 100n },
+   * ])
+   * // '0x...'
+   * ```
+   */
+  encodeCalls: (calls: readonly Call[]) => Promise<Hex>
+  /**
+   * Retrieves the calldata for deployer call to deploy a Smart Account.
+   * If the Smart Account has already been deployed, this will return undefined values.
+   *
+   * @example Counterfactual account
+   * ```ts
+   * const { deployer, deployerData } = await account.getFactoryArgs()
+   * // { deployer: '0x...', deployerData: '0x...' }
+   * ```
+   *
+   * @example Deployed account
+   * ```ts
+   * const { deployer, fdeployerData } = await account.getFactoryArgs()
+   * // { deployer: undefined, deployerData: undefined }
+   * ```
+   */
+  getDeployerArgs: () => Promise<{
+    deployer?: Address | undefined
+    deployerData?: Hex | undefined
+  }>
+  /**
+   * Retrieves the nonce of the Account.
+   *
+   * @example
+   * ```ts
+   * const nonce = await account.getNonce()
+   * // 1n
+   * ```
+   */
+  getNonce?:
+    | ((
+        parameters?: { key?: bigint | undefined } | undefined,
+      ) => Promise<number>)
+    | undefined
+  /**
+   * Retrieves the User Operation "stub" signature for gas estimation.
+   *
+   * ```ts
+   * const signature = await account.getStubSignature()
+   * // '0x...'
+   * ```
+   */
+  getStubSignature: () => Promise<Hex>
+  /** Custom nonce key manager. */
+  nonceKeyManager?: NonceManager | undefined
+  /**
+   * Signs a hash via the Smart Account's owner.
+   *
+   * @example
+   * ```ts
+   * const signature = await account.sign({
+   *   hash: '0x...'
+   * })
+   * // '0x...'
+   * ```
+   */
+  sign?: ((parameters: { hash: Hash }) => Promise<Hex>) | undefined
+  /**
+   * Signs a [EIP-191 Personal Sign message](https://eips.ethereum.org/EIPS/eip-191).
+   *
+   * @example
+   * ```ts
+   * const signature = await account.signMessage({
+   *   message: 'Hello, World!'
+   * })
+   * // '0x...'
+   * ```
+   */
+  signMessage: (parameters: { message: SignableMessage }) => Promise<Hex>
+  /**
+   * Signs [EIP-712 Typed Data](https://eips.ethereum.org/EIPS/eip-712).
+   *
+   * @example
+   * ```ts
+   * const signature = await account.signTypedData({
+   *   domain,
+   *   types,
+   *   primaryType: 'Mail',
+   *   message,
+   * })
+   * ```
+   */
+  signTypedData: <
+    const typedData extends TypedData | Record<string, unknown>,
+    primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
+  >(
+    parameters: TypedDataDefinition<typedData, primaryType>,
+  ) => Promise<Hex>
+  /**
+   * Signs the RIP-7560 Transaction.
+   *
+   * @example
+   * ```ts
+   * const signature = await account.signTransaction({
+   *   chainId: 1,
+   *   transaction,
+   * })
+   * ```
+   */
+
+  signTransaction: <
+    serializer extends
+      SerializeTransactionFn<TransactionSerializable> = SerializeTransactionFn<TransactionSerializable>,
+    transaction extends Parameters<serializer>[0] = Parameters<serializer>[0],
+  >(
+    transaction: transaction,
+    options?:
+      | {
+          serializer?: serializer | undefined
+        }
+      | undefined,
+  ) => Promise<
+    IsNarrowable<
+      TransactionSerialized<GetTransactionType<transaction>>,
+      Hex
+    > extends true
+      ? TransactionSerialized<GetTransactionType<transaction>>
+      : Hex
+  >
+  /** User Operation configuration properties. */
+  transaction?:
+    | {
+        /** Prepares gas properties for the User Operation request. */
+        estimateGas?:
+          | ((
+              transaction: TransactionRequest,
+            ) => Promise<
+              ExactPartial<EstimateRIP7560TransactionGasReturnType> | undefined
+            >)
+          | undefined
+      }
+    | undefined
+}
+
+export type NativeSmartAccount<
+  implementation extends
+    NativeSmartAccountImplementation = NativeSmartAccountImplementation,
+> = Assign<
+  implementation['extend'],
+  Assign<
+    implementation,
+    {
+      /** Address of the Smart Account. */
+      address: Address
+      /**
+       * Retrieves the nonce of the Account.
+       *
+       * @example
+       * ```ts
+       * const nonce = await account.getNonce()
+       * // 1n
+       * ```
+       */
+      getNonce: NonNullable<NativeSmartAccountImplementation['getNonce']>
+      /** Whether or not the Smart Account has been deployed. */
+      isDeployed: () => Promise<boolean>
+      /** Type of account. */
+      type: 'native-smart'
+    }
+  >
+>
+
+export type NativeWebAuthnAccount = {
+  publicKey: Hex
+  sign: ({ hash }: { hash: Hash }) => Promise<WebAuthnSignReturnType>
+  signMessage: ({
+    message,
+  }: { message: SignableMessage }) => Promise<WebAuthnSignReturnType>
+  signTypedData: <
+    const typedData extends TypedDataDefinition | Record<string, unknown>,
+    primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
+  >(
+    typedDataDefinition: TypedDataDefinition<typedData, primaryType>,
+  ) => Promise<WebAuthnSignReturnType>
+  type: 'native-webAuthn'
+}

--- a/src/experimental/rip7560/accounts/address.ts
+++ b/src/experimental/rip7560/accounts/address.ts
@@ -1,0 +1,2 @@
+export const nonceManagerPredeployAddress =
+  '0x4200000000000000000000000000000000000024' as const

--- a/src/experimental/rip7560/accounts/implementations/toSimpleNativeSmartAccount.ts
+++ b/src/experimental/rip7560/accounts/implementations/toSimpleNativeSmartAccount.ts
@@ -1,0 +1,692 @@
+import type { Address, TypedData } from 'abitype'
+
+import type { LocalAccount } from '../../../../accounts/types.js'
+import { readContract } from '../../../../actions/public/readContract.js'
+import type { Client } from '../../../../clients/createClient.js'
+import { BaseError } from '../../../../errors/base.js'
+import type { Hash, Hex } from '../../../../types/misc.js'
+import type { TransactionSerializable } from '../../../../types/transaction.js'
+import type { TypedDataDefinition } from '../../../../types/typedData.js'
+import type { Assign, Prettify } from '../../../../types/utils.js'
+import { decodeFunctionData } from '../../../../utils/abi/decodeFunctionData.js'
+import { encodeFunctionData } from '../../../../utils/abi/encodeFunctionData.js'
+import { keccak256, serializeTransaction } from '../../../../utils/index.js'
+import { hashMessage } from '../../../../utils/signature/hashMessage.js'
+import { hashTypedData } from '../../../../utils/signature/hashTypedData.js'
+import { toNativeSmartAccount } from '../toNativeSmartAccount.js'
+import type {
+  NativeSmartAccount,
+  NativeSmartAccountImplementation,
+} from '../types.js'
+
+export type ToSimpleNativeSmartAccountParameters = {
+  address?: Address | undefined
+  client: Client
+  owner: LocalAccount
+  nonce?: bigint | undefined
+}
+
+export type ToSimpleNativeSmartAccountReturnType = Prettify<
+  NativeSmartAccount<SimpleNativeSmartAccountImplementation>
+>
+
+export type SimpleNativeSmartAccountImplementation = Assign<
+  NativeSmartAccountImplementation,
+  {
+    decodeCalls: NonNullable<NativeSmartAccountImplementation['decodeCalls']>
+    sign: NonNullable<NativeSmartAccountImplementation['sign']>
+  }
+>
+
+/**
+ * @description Create a Simple Native Smart Account.
+ *
+ * @param parameters - {@link ToSimpleNativeSmartAccountParameters}
+ * @returns Simple Native Smart Account. {@link ToSimpleNativeSmartAccountReturnType}
+ *
+ * @example
+ * import { toSimpleNativeSmartAccount } from 'viem/experimental/rip7560'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ * import { client } from './client.js'
+ *
+ * const account = toSimpleNativeSmartAccount({
+ *   client,
+ *   owner: privateKeyToAccount('0x...'),
+ * })
+ */
+export async function toSimpleNativeSmartAccount(
+  parameters: ToSimpleNativeSmartAccountParameters,
+): Promise<ToSimpleNativeSmartAccountReturnType> {
+  const { client, owner, nonce = 0n } = parameters
+
+  let address = parameters.address
+  const ownerAddr = owner.address as Hex
+
+  const deployer = {
+    abi: deployerAbi,
+    // TODO: Change this after the deployer contract is deployed. Now copied from Coinbase Wallet
+    address: '0x0ba5ed0c6aa8c49038f819e587e2633c4a9f428a',
+  } as const
+
+  return toNativeSmartAccount({
+    client,
+
+    extend: { abi, deployer },
+
+    async decodeCalls(data) {
+      const result = decodeFunctionData({
+        abi,
+        data,
+      })
+
+      if (result.functionName === 'execute')
+        return [
+          { to: result.args[0], value: result.args[1], data: result.args[2] },
+        ]
+      if (result.functionName === 'executeBatch')
+        return result.args[0].map((arg) => ({
+          to: arg.target,
+          value: arg.value,
+          data: arg.data,
+        }))
+      throw new BaseError(`unable to decode calls for "${result.functionName}"`)
+    },
+
+    async encodeCalls(calls) {
+      if (calls.length === 1)
+        return encodeFunctionData({
+          abi,
+          functionName: 'execute',
+          args: [calls[0].to, calls[0].value ?? 0n, calls[0].data ?? '0x'],
+        })
+      return encodeFunctionData({
+        abi,
+        functionName: 'executeBatch',
+        args: [
+          calls.map((call) => ({
+            data: call.data ?? '0x',
+            target: call.to,
+            value: call.value ?? 0n,
+          })),
+        ],
+      })
+    },
+
+    async getAddress() {
+      address ??= await readContract(client, {
+        ...deployer,
+        functionName: 'getAddress',
+        args: [ownerAddr, nonce],
+      })
+      return address
+    },
+
+    async getDeployerArgs() {
+      const deployerData = encodeFunctionData({
+        abi: deployer.abi,
+        functionName: 'createAccount',
+        args: [ownerAddr, nonce],
+      })
+      return { deployer: deployer.address, deployerData }
+    },
+
+    async getStubSignature() {
+      return '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c' as Hex
+    },
+
+    async sign(parameters) {
+      const address = await this.getAddress()
+
+      const hash = toReplaySafeHash({
+        address,
+        chainId: client.chain!.id,
+        hash: parameters.hash,
+      })
+
+      const signature = await sign({ hash, owner })
+
+      return signature
+    },
+
+    async signMessage(parameters) {
+      const { message } = parameters
+      const address = await this.getAddress()
+
+      const hash = toReplaySafeHash({
+        address,
+        chainId: client.chain!.id,
+        hash: hashMessage(message),
+      })
+
+      const signature = await sign({ hash, owner })
+
+      return signature
+    },
+
+    async signTypedData(parameters) {
+      const { domain, types, primaryType, message } =
+        parameters as TypedDataDefinition<TypedData, string>
+      const address = await this.getAddress()
+
+      const hash = toReplaySafeHash({
+        address,
+        chainId: client.chain!.id,
+        hash: hashTypedData({
+          domain,
+          message,
+          primaryType,
+          types,
+        }),
+      })
+
+      const signature = await sign({ hash, owner })
+
+      return signature
+    },
+
+    async signTransaction(parameters) {
+      const { chainId = client.chain!.id, ...transaction } = parameters
+
+      const address = await this.getAddress()
+      const serializableTransaction = {
+        ...transaction,
+        sender: address,
+        chainId,
+      } as TransactionSerializable
+      const hash = keccak256(serializeTransaction(serializableTransaction))
+
+      const signature = await sign({ hash, owner })
+
+      return signature
+    },
+
+    transaction: {
+      async estimateGas(transaction) {
+        return {
+          verificationGasLimit: BigInt(
+            Number(transaction.verificationGasLimit ?? 0n),
+          ),
+        }
+      },
+    },
+  })
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+// Utilities
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+/** @internal */
+export async function sign({
+  hash,
+  owner,
+}: { hash: Hash; owner: LocalAccount }) {
+  if (owner.sign) return owner.sign({ hash })
+
+  throw new BaseError('`owner` does not support raw sign.')
+}
+
+/** @internal */
+export function toReplaySafeHash({
+  address,
+  chainId,
+  hash,
+}: { address: Address; chainId: number; hash: Hash }) {
+  return hashTypedData({
+    domain: {
+      chainId,
+      name: 'Simple Native Smart Wallet',
+      verifyingContract: address,
+      version: '1',
+    },
+    types: {
+      SimpleNativeSmartWalletMessage: [
+        {
+          name: 'hash',
+          type: 'bytes32',
+        },
+      ],
+    },
+    primaryType: 'SimpleNativeSmartWalletMessage',
+    message: {
+      hash,
+    },
+  })
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+// Constants
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+// TODO: Change this after the contract is determined. Now copied from Coinbase Wallet.
+const abi = [
+  { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
+  {
+    inputs: [{ name: 'owner', type: 'bytes' }],
+    name: 'AlreadyOwner',
+    type: 'error',
+  },
+  { inputs: [], name: 'Initialized', type: 'error' },
+  {
+    inputs: [{ name: 'owner', type: 'bytes' }],
+    name: 'InvalidEthereumAddressOwner',
+    type: 'error',
+  },
+  {
+    inputs: [{ name: 'key', type: 'uint256' }],
+    name: 'InvalidNonceKey',
+    type: 'error',
+  },
+  {
+    inputs: [{ name: 'owner', type: 'bytes' }],
+    name: 'InvalidOwnerBytesLength',
+    type: 'error',
+  },
+  { inputs: [], name: 'LastOwner', type: 'error' },
+  {
+    inputs: [{ name: 'index', type: 'uint256' }],
+    name: 'NoOwnerAtIndex',
+    type: 'error',
+  },
+  {
+    inputs: [{ name: 'ownersRemaining', type: 'uint256' }],
+    name: 'NotLastOwner',
+    type: 'error',
+  },
+  {
+    inputs: [{ name: 'selector', type: 'bytes4' }],
+    name: 'SelectorNotAllowed',
+    type: 'error',
+  },
+  { inputs: [], name: 'Unauthorized', type: 'error' },
+  { inputs: [], name: 'UnauthorizedCallContext', type: 'error' },
+  { inputs: [], name: 'UpgradeFailed', type: 'error' },
+  {
+    inputs: [
+      { name: 'index', type: 'uint256' },
+      { name: 'expectedOwner', type: 'bytes' },
+      { name: 'actualOwner', type: 'bytes' },
+    ],
+    name: 'WrongOwnerAtIndex',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+
+        name: 'index',
+        type: 'uint256',
+      },
+      { indexed: false, name: 'owner', type: 'bytes' },
+    ],
+    name: 'AddOwner',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+
+        name: 'index',
+        type: 'uint256',
+      },
+      { indexed: false, name: 'owner', type: 'bytes' },
+    ],
+    name: 'RemoveOwner',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+
+        name: 'implementation',
+        type: 'address',
+      },
+    ],
+    name: 'Upgraded',
+    type: 'event',
+  },
+  { stateMutability: 'payable', type: 'fallback' },
+  {
+    inputs: [],
+    name: 'REPLAYABLE_NONCE_KEY',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'owner', type: 'address' }],
+    name: 'addOwnerAddress',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'x', type: 'bytes32' },
+      { name: 'y', type: 'bytes32' },
+    ],
+    name: 'addOwnerPublicKey',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'functionSelector', type: 'bytes4' }],
+    name: 'canSkipChainIdValidation',
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'domainSeparator',
+    outputs: [{ name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'eip712Domain',
+    outputs: [
+      { name: 'fields', type: 'bytes1' },
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+      { name: 'extensions', type: 'uint256[]' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'entryPoint',
+    outputs: [{ name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'target', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'data', type: 'bytes' },
+    ],
+    name: 'execute',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { name: 'target', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'data', type: 'bytes' },
+        ],
+
+        name: 'calls',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'executeBatch',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'calls', type: 'bytes[]' }],
+    name: 'executeWithoutChainIdValidation',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { name: 'sender', type: 'address' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'initCode', type: 'bytes' },
+          { name: 'callData', type: 'bytes' },
+          { name: 'callGasLimit', type: 'uint256' },
+          {
+            name: 'verificationGasLimit',
+            type: 'uint256',
+          },
+          {
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { name: 'maxFeePerGas', type: 'uint256' },
+          {
+            name: 'maxPriorityFeePerGas',
+            type: 'uint256',
+          },
+          { name: 'paymasterAndData', type: 'bytes' },
+          { name: 'signature', type: 'bytes' },
+        ],
+
+        name: 'userOp',
+        type: 'tuple',
+      },
+    ],
+    name: 'getUserOpHashWithoutChainId',
+    outputs: [{ name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'implementation',
+    outputs: [{ name: '$', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'owners', type: 'bytes[]' }],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'account', type: 'address' }],
+    name: 'isOwnerAddress',
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'account', type: 'bytes' }],
+    name: 'isOwnerBytes',
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'x', type: 'bytes32' },
+      { name: 'y', type: 'bytes32' },
+    ],
+    name: 'isOwnerPublicKey',
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'hash', type: 'bytes32' },
+      { name: 'signature', type: 'bytes' },
+    ],
+    name: 'isValidSignature',
+    outputs: [{ name: 'result', type: 'bytes4' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'nextOwnerIndex',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'index', type: 'uint256' }],
+    name: 'ownerAtIndex',
+    outputs: [{ name: '', type: 'bytes' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'ownerCount',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'proxiableUUID',
+    outputs: [{ name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'index', type: 'uint256' },
+      { name: 'owner', type: 'bytes' },
+    ],
+    name: 'removeLastOwner',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'index', type: 'uint256' },
+      { name: 'owner', type: 'bytes' },
+    ],
+    name: 'removeOwnerAtIndex',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'removedOwnersCount',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'hash', type: 'bytes32' }],
+    name: 'replaySafeHash',
+    outputs: [{ name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'newImplementation', type: 'address' },
+      { name: 'data', type: 'bytes' },
+    ],
+    name: 'upgradeToAndCall',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { name: 'sender', type: 'address' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'initCode', type: 'bytes' },
+          { name: 'callData', type: 'bytes' },
+          { name: 'callGasLimit', type: 'uint256' },
+          {
+            name: 'verificationGasLimit',
+            type: 'uint256',
+          },
+          {
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { name: 'maxFeePerGas', type: 'uint256' },
+          {
+            name: 'maxPriorityFeePerGas',
+            type: 'uint256',
+          },
+          { name: 'paymasterAndData', type: 'bytes' },
+          { name: 'signature', type: 'bytes' },
+        ],
+
+        name: 'userOp',
+        type: 'tuple',
+      },
+      { name: 'userOpHash', type: 'bytes32' },
+      { name: 'missingAccountFunds', type: 'uint256' },
+    ],
+    name: 'validateUserOp',
+    outputs: [{ name: 'validationData', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  { stateMutability: 'payable', type: 'receive' },
+] as const
+
+const deployerAbi = [
+  {
+    inputs: [{ name: 'implementation_', type: 'address' }],
+    stateMutability: 'payable',
+    type: 'constructor',
+  },
+  { inputs: [], name: 'OwnerRequired', type: 'error' },
+  {
+    inputs: [
+      { name: 'owners', type: 'address' },
+      { name: 'nonce', type: 'uint256' },
+    ],
+    name: 'createAccount',
+    outputs: [
+      {
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { name: 'owners', type: 'address' },
+      { name: 'nonce', type: 'uint256' },
+    ],
+    name: 'getAddress',
+    outputs: [{ name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'implementation',
+    outputs: [{ name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'initCodeHash',
+    outputs: [{ name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const

--- a/src/experimental/rip7560/accounts/toNativeSmartAccount.ts
+++ b/src/experimental/rip7560/accounts/toNativeSmartAccount.ts
@@ -1,0 +1,141 @@
+import { parseAbi } from 'abitype'
+
+import { getCode } from '../../../actions/public/getCode.js'
+import { readContract } from '../../../actions/public/readContract.js'
+import type { Prettify } from '../../../types/utils.js'
+import { getAction } from '../../../utils/getAction.js'
+import { createNonceManager } from '../../../utils/nonceManager.js'
+import { serializeErc6492Signature } from '../../../utils/signature/serializeErc6492Signature.js'
+import { nonceManagerPredeployAddress } from './address.js'
+import type {
+  NativeSmartAccount,
+  NativeSmartAccountImplementation,
+} from './types.js'
+
+export type ToNativeSmartAccountParameters<extend extends object = object> =
+  NativeSmartAccountImplementation<extend>
+
+export type ToNativeSmartAccountReturnType<
+  implementation extends
+    NativeSmartAccountImplementation = NativeSmartAccountImplementation,
+> = Prettify<NativeSmartAccount<implementation>>
+
+/**
+ * @description Creates a Smart Account with a provided account implementation.
+ *
+ * @param parameters - {@link ToNativeSmartAccountParameters}
+ * @returns A RIP-7560 Smart Account. {@link ToNativeSmartAccountReturnType}
+ */
+export async function toNativeSmartAccount<
+  implementation extends NativeSmartAccountImplementation,
+>(
+  implementation: implementation,
+): Promise<ToNativeSmartAccountReturnType<implementation>> {
+  const {
+    extend,
+    nonceKeyManager = createNonceManager({
+      source: {
+        get() {
+          return Date.now()
+        },
+        set() {},
+      },
+    }),
+    ...rest
+  } = implementation
+
+  let deployed = false
+
+  const address = await implementation.getAddress()
+
+  return {
+    ...extend,
+    ...rest,
+    address,
+    async getDeployerArgs() {
+      if ('isDeployed' in this && (await this.isDeployed()))
+        return { deployer: undefined, deployerData: undefined }
+      return implementation.getDeployerArgs()
+    },
+    async getNonce(parameters) {
+      const key =
+        parameters?.key ??
+        BigInt(
+          await nonceKeyManager.consume({
+            address,
+            chainId: implementation.client.chain!.id!,
+            client: implementation.client,
+          }),
+        )
+
+      if (implementation.getNonce)
+        return await implementation.getNonce({ ...parameters, key })
+
+      const nonce = await readContract(implementation.client, {
+        abi: parseAbi([
+          'function getNonce(address, uint192) pure returns (uint256)',
+        ]),
+        address: nonceManagerPredeployAddress,
+        functionName: 'getNonce',
+        args: [address, key],
+      })
+      return nonce
+    },
+    async isDeployed() {
+      if (deployed) return true
+      const code = await getAction(
+        implementation.client,
+        getCode,
+        'getCode',
+      )({
+        address,
+      })
+      deployed = Boolean(code)
+      return deployed
+    },
+    ...(implementation.sign
+      ? {
+          async sign(parameters) {
+            const [{ deployer, deployerData }, signature] = await Promise.all([
+              this.getDeployerArgs(),
+              implementation.sign!(parameters),
+            ])
+            if (deployer && deployerData)
+              return serializeErc6492Signature({
+                address: deployer,
+                data: deployerData,
+                signature,
+              })
+            return signature
+          },
+        }
+      : {}),
+    async signMessage(parameters) {
+      const [{ deployer, deployerData }, signature] = await Promise.all([
+        this.getDeployerArgs(),
+        implementation.signMessage(parameters),
+      ])
+      if (deployer && deployerData)
+        return serializeErc6492Signature({
+          address: deployer,
+          data: deployerData,
+          signature,
+        })
+      return signature
+    },
+    async signTypedData(parameters) {
+      const [{ deployer, deployerData }, signature] = await Promise.all([
+        this.getDeployerArgs(),
+        implementation.signTypedData(parameters),
+      ])
+      if (deployer && deployerData)
+        return serializeErc6492Signature({
+          address: deployer,
+          data: deployerData,
+          signature,
+        })
+      return signature
+    },
+    type: 'native-smart',
+  } as ToNativeSmartAccountReturnType<implementation>
+}

--- a/src/experimental/rip7560/accounts/types.ts
+++ b/src/experimental/rip7560/accounts/types.ts
@@ -1,5 +1,4 @@
 import type { Address, TypedData } from 'abitype'
-import type { SignReturnType as WebAuthnSignReturnType } from 'webauthn-p256'
 
 import type { Client } from '../../../clients/createClient.js'
 import type { Hash, Hex, SignableMessage } from '../../../types/misc.js'
@@ -225,18 +224,3 @@ export type NativeSmartAccount<
     }
   >
 >
-
-export type NativeWebAuthnAccount = {
-  publicKey: Hex
-  sign: ({ hash }: { hash: Hash }) => Promise<WebAuthnSignReturnType>
-  signMessage: ({
-    message,
-  }: { message: SignableMessage }) => Promise<WebAuthnSignReturnType>
-  signTypedData: <
-    const typedData extends TypedDataDefinition | Record<string, unknown>,
-    primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
-  >(
-    typedDataDefinition: TypedDataDefinition<typedData, primaryType>,
-  ) => Promise<WebAuthnSignReturnType>
-  type: 'native-webAuthn'
-}

--- a/src/experimental/rip7560/types/calls.ts
+++ b/src/experimental/rip7560/types/calls.ts
@@ -1,0 +1,7 @@
+import type { Hex } from '../../../types/misc.js'
+
+export type Calls<uint256 = bigint> = {
+  to: Hex
+  data?: Hex | undefined
+  value?: uint256 | undefined
+}

--- a/src/experimental/rip7560/types/gas.ts
+++ b/src/experimental/rip7560/types/gas.ts
@@ -1,0 +1,4 @@
+export type EstimateRIP7560TransactionGasReturnType<uint256 = bigint> = {
+  verificationGasLimit: uint256
+  callGasLimit: uint256
+}

--- a/src/op-stack/actions/estimateTotalFee.ts
+++ b/src/op-stack/actions/estimateTotalFee.ts
@@ -78,7 +78,7 @@ export async function estimateTotalFee<
 
   const [l1Fee, l2Gas, l2GasPrice] = await Promise.all([
     estimateL1Fee(client, request as EstimateL1FeeParameters),
-    estimateGas(client, request as EstimateGasParameters),
+    estimateGas(client, request as EstimateGasParameters) as Promise<bigint>,
     getGasPrice(client),
   ])
 

--- a/src/op-stack/actions/estimateTotalGas.ts
+++ b/src/op-stack/actions/estimateTotalGas.ts
@@ -73,7 +73,7 @@ export async function estimateTotalGas<
 
   const [l1Gas, l2Gas] = await Promise.all([
     estimateL1Gas(client, request as EstimateL1GasParameters),
-    estimateGas(client, request as EstimateGasParameters),
+    estimateGas(client, request as EstimateGasParameters) as Promise<bigint>,
   ])
 
   return l1Gas + l2Gas

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -686,7 +686,12 @@ export type PublicRpcSchema = [
           block: BlockNumber | BlockTag,
           stateOverride: RpcStateOverride,
         ]
-    ReturnType: Quantity
+    ReturnType:
+      | Quantity
+      | {
+          verificationGasLimit: Quantity
+          callGasLimit: Quantity
+        }
   },
   /**
    * @description Returns a collection of historical gas information

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -335,7 +335,7 @@ export type TransactionRequestRIP7560<
     paymasterData?: Hex | undefined
     paymasterVerificationGasLimit?: quantity | undefined
     paymasterPostOpGasLimit?: quantity | undefined
-    authorizationData: Hex
+    authorizationData?: Hex | undefined
   }
 
 export type TransactionRequest<quantity = bigint, index = number> = OneOf<

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -109,14 +109,15 @@ export function serializeTransaction<
   _transactionType extends TransactionType = GetTransactionType<transaction>,
 >(
   transaction: transaction,
-  signature?: Signature | Hex | undefined,
+  signature?: Signature | undefined,
+  authorizationData?: Hex | undefined,
 ): SerializedTransactionReturnType<transaction, _transactionType> {
   const type = getTransactionType(transaction) as GetTransactionType
 
   if (type === 'rip7560' && (!signature || isHex(signature)))
     return serializeTransactionRIP7560(
       transaction as TransactionSerializableRIP7560,
-      signature,
+      authorizationData,
     ) as SerializedTransactionReturnType<transaction>
 
   if (type === 'eip1559' && !isHex(signature))


### PR DESCRIPTION
Added experimental folder to apply RIP-7560 features on viem.

Note that some features are not complete, such as getting paymaster data from paymaster client when estimating gas.
Also, toSimpleNativeAccount.ts is based on toCoinbaseAccount.ts at account-abstraction, and the abis and factory address will be fixed after completing contracts.
